### PR TITLE
Fix bug: Go 1.18 have no reflect.TypeFor function

### DIFF
--- a/autowire.go
+++ b/autowire.go
@@ -3,12 +3,11 @@ package autowire
 import (
 	"context"
 	"fmt"
-	"reflect"
 )
 
 // Build builds object for the specified type within a container
 func Build[T any](c Container, opts ...ContextOption) (value T, err error) {
-	targetType := reflect.TypeFor[T]()
+	targetType := typeFor[T]()
 
 	val, err := c.Build(targetType, opts...)
 	if err != nil {
@@ -26,7 +25,7 @@ func Build[T any](c Container, opts ...ContextOption) (value T, err error) {
 // BuildWithCtx builds object for the specified type within a container.
 // This function will pass the specified context object to every provider that requires a context.
 func BuildWithCtx[T any](ctx context.Context, c Container, opts ...ContextOption) (value T, err error) {
-	targetType := reflect.TypeFor[T]()
+	targetType := typeFor[T]()
 
 	val, err := c.BuildWithCtx(ctx, targetType, opts...)
 	if err != nil {
@@ -44,7 +43,7 @@ func BuildWithCtx[T any](ctx context.Context, c Container, opts ...ContextOption
 // Get gets object of a type within a container.
 // If no object is created for the type or `sharedMode` is `false`, ErrNotFound is returned.
 func Get[T any](c Container) (value T, err error) {
-	targetType := reflect.TypeFor[T]()
+	targetType := typeFor[T]()
 
 	val, err := c.Get(targetType)
 	if err != nil {
@@ -61,5 +60,5 @@ func Get[T any](c Container) (value T, err error) {
 
 // Resolve builds dependency graph for the specified type within a container
 func Resolve[T any](c Container) (DependencyGraph, error) {
-	return c.Resolve(reflect.TypeFor[T]())
+	return c.Resolve(typeFor[T]())
 }

--- a/container_resolve_test.go
+++ b/container_resolve_test.go
@@ -1,7 +1,6 @@
 package autowire
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -71,27 +70,27 @@ func TestContainerResolve_Success(t *testing.T) {
 		c, err := NewContainer([]any{NewSrv1_OK_With_Need_Srv2_Srv3_IntSlice, NewSrv2_OK_With_Need_Srv4_Srv5,
 			NewSrv3_OK, NewSrv4_OK, NewSrv5_OK, &struct1_OK, &struct5_OK})
 		assert.Nil(t, err)
-		dg, err := c.Resolve(reflect.TypeFor[Service1]())
+		dg, err := c.Resolve(typeFor[Service1]())
 		assert.Nil(t, err)
-		assert.Equal(t, reflect.TypeFor[Service1](), dg.TargetType)
+		assert.Equal(t, typeFor[Service1](), dg.TargetType)
 		assert.Equal(t, 3, len(dg.Dependencies))
 
 		dg1 := dg.Dependencies[0]
-		assert.Equal(t, reflect.TypeFor[Service2](), dg1.TargetType)
+		assert.Equal(t, typeFor[Service2](), dg1.TargetType)
 		assert.Equal(t, 2, len(dg1.Dependencies))
 		dg11 := dg1.Dependencies[0]
-		assert.Equal(t, reflect.TypeFor[Service4](), dg11.TargetType)
+		assert.Equal(t, typeFor[Service4](), dg11.TargetType)
 		assert.Equal(t, 0, len(dg11.Dependencies))
 		dg12 := dg1.Dependencies[1]
-		assert.Equal(t, reflect.TypeFor[Service5](), dg12.TargetType)
+		assert.Equal(t, typeFor[Service5](), dg12.TargetType)
 		assert.Equal(t, 0, len(dg12.Dependencies))
 
 		dg2 := dg.Dependencies[1]
-		assert.Equal(t, reflect.TypeFor[Service3](), dg2.TargetType)
+		assert.Equal(t, typeFor[Service3](), dg2.TargetType)
 		assert.Equal(t, 0, len(dg2.Dependencies))
 
 		dg3 := dg.Dependencies[2]
-		assert.Equal(t, reflect.TypeFor[[]int](), dg3.TargetType)
+		assert.Equal(t, typeFor[[]int](), dg3.TargetType)
 		assert.Equal(t, 0, len(dg3.Dependencies))
 	})
 }

--- a/container_test.go
+++ b/container_test.go
@@ -48,7 +48,7 @@ func TestContainerGet(t *testing.T) {
 	t.Run("Not found", func(t *testing.T) {
 		c, err := NewContainer([]any{NewSrv1_OK})
 		assert.Nil(t, err)
-		_, err = c.Get(reflect.TypeFor[Service1]())
+		_, err = c.Get(typeFor[Service1]())
 		assert.ErrorIs(t, err, ErrNotFound)
 		assert.Contains(t, err.Error(), "ErrNotFound: object not found for type 'autowire.Service1'")
 	})
@@ -56,12 +56,12 @@ func TestContainerGet(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		c, err := NewContainer([]any{NewSrv1_OK})
 		assert.Nil(t, err)
-		v1, err := c.Build(reflect.TypeFor[Service1]())
+		v1, err := c.Build(typeFor[Service1]())
 		assert.Nil(t, err)
-		v2, err := c.Get(reflect.TypeFor[Service1]())
+		v2, err := c.Get(typeFor[Service1]())
 		assert.Nil(t, err)
 		assert.Equal(t, v1, v2)
-		_, err = c.Get(reflect.TypeFor[Service2]())
+		_, err = c.Get(typeFor[Service2]())
 		assert.ErrorIs(t, err, ErrNotFound)
 	})
 }

--- a/func_provider_test.go
+++ b/func_provider_test.go
@@ -56,7 +56,7 @@ func TestFuncProvider_Success(t *testing.T) {
 		ps1, err := parseProviders(NewSrv1_OK)
 		assert.Nil(t, err)
 		assert.Equal(t, 1, len(ps1.GetAll()))
-		assert.Equal(t, reflect.TypeFor[Service1](), ps1.GetAll()[0].TargetTypes()[0])
+		assert.Equal(t, typeFor[Service1](), ps1.GetAll()[0].TargetTypes()[0])
 		assert.Equal(t, reflect.TypeOf(NewSrv1_OK), reflect.TypeOf(ps1.GetAll()[0].Source()))
 	})
 }

--- a/provider.go
+++ b/provider.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	typeError = reflect.TypeFor[error]()
+	typeError = typeFor[error]()
 )
 
 // Provider a provider is an `object creator` and provide the object to a container.

--- a/struct_provider_test.go
+++ b/struct_provider_test.go
@@ -1,7 +1,6 @@
 package autowire
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -58,10 +57,10 @@ func TestStructProvider_Success(t *testing.T) {
 		ps1, err := parseProviders(&struct7_OK_Nested)
 		assert.Nil(t, err)
 		assert.Equal(t, 7, len(ps1.GetAll())) // 5 fields and 2 nested structs themselves
-		prov1, err := ps1.GetFor(reflect.TypeFor[Nested1]())
+		prov1, err := ps1.GetFor(typeFor[Nested1]())
 		assert.Nil(t, err)
 		assert.Equal(t, prov1.Source(), &struct7_OK_Nested)
-		prov2, err := ps1.GetFor(reflect.TypeFor[*Nested2]())
+		prov2, err := ps1.GetFor(typeFor[*Nested2]())
 		assert.Nil(t, err)
 		assert.Equal(t, prov2.Source(), &struct7_OK_Nested)
 	})

--- a/util.go
+++ b/util.go
@@ -1,0 +1,8 @@
+package autowire
+
+import "reflect"
+
+// typeFor returns the [Type] that represents the type argument T.
+func typeFor[T any]() reflect.Type {
+	return reflect.TypeOf((*T)(nil)).Elem()
+}

--- a/value_provider.go
+++ b/value_provider.go
@@ -29,6 +29,6 @@ func (p *valueProvider) Build(ctx *Context, targetType reflect.Type) (reflect.Va
 func newValueProvider[T any](provSrc T, provVal reflect.Value) *valueProvider {
 	return &valueProvider{
 		baseProvider: baseProvider{source: provSrc, sourceVal: provVal},
-		targetType:   reflect.TypeFor[T](),
+		targetType:   typeFor[T](),
 	}
 }

--- a/value_provider_test.go
+++ b/value_provider_test.go
@@ -11,7 +11,7 @@ func TestValueProvider(t *testing.T) {
 	t.Run("Success with primitive type", func(t *testing.T) {
 		p := newValueProvider(123, reflect.ValueOf(123))
 		assert.Equal(t, 1, len(p.TargetTypes()))
-		assert.Equal(t, reflect.TypeFor[int](), p.TargetTypes()[0])
+		assert.Equal(t, typeFor[int](), p.TargetTypes()[0])
 		assert.Equal(t, 0, len(p.DependentTypes()))
 	})
 
@@ -19,7 +19,7 @@ func TestValueProvider(t *testing.T) {
 		v := "abc"
 		p := newValueProvider(&v, reflect.ValueOf(&v))
 		assert.Equal(t, 1, len(p.TargetTypes()))
-		assert.Equal(t, reflect.TypeFor[*string](), p.TargetTypes()[0])
+		assert.Equal(t, typeFor[*string](), p.TargetTypes()[0])
 		assert.Equal(t, 0, len(p.DependentTypes()))
 	})
 }


### PR DESCRIPTION
## What
- Copied reflect.TypeFor() from the newer version of Go.